### PR TITLE
Fixed incorrect validation of US2 region

### DIFF
--- a/modules/logpush-job/variables.tf
+++ b/modules/logpush-job/variables.tf
@@ -3,7 +3,7 @@ variable "coralogix_region" {
   type        = string
   default     = "Europe"
     validation {
-    condition = contains(["Europe","Europe2","India","Singapore","US"], var.coralogix_region)
+    condition = contains(["Europe","Europe2","India","Singapore","US","US2"], var.coralogix_region)
     error_message = "The coralogix region must be on of these values: [Europe, Europe2, India, Singapore, US, US2]."
   }
 }


### PR DESCRIPTION
Missing US2 region in the `coralogix_region` variable causes incorrect validation. 