### PR TITLE
feat: Add support for AP3 region and remove deprecated field

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,15 +19,15 @@ jobs:
     if: github.repository_owner == 'coralogix'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           fetch-depth: 0
 
       - name: Release
-        uses: cycjimmy/semantic-release-action@v2
+        uses: cycjimmy/semantic-release-action@v3.4.2
         with:
-          semantic_version: 19.0.2
+          semantic_version: 19.0.5
           extra_plugins: |
             conventional-changelog-conventionalcommits@4.6.3
         env:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -10,7 +10,9 @@
       {
         "preset": "conventionalcommits",
         "releaseRules": [
-          {"message": "*", "release": "patch"}
+          {"message": "fix:*", "release": "patch"},
+          {"message": "feat:*", "release": "minor"},
+          {"message": "major:*", "release": "major"}
         ]
       }
     ],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## v1.0.14 / 2024-12-15
+### 💡 Enhancements 💡
+- Add support for new rgion `AP3`, and for  regions syntax: `EU1`, `EU2`, `AP1`, `AP2`, `US1`
+- Replaced depricated filed `frequency` with `max_upload_bytes`, `max_upload_interval_seconds` and  `max_upload_records` 
+- Add default value for `coralogix_application_name` and `coralogix_subsystem_name`: `cx-Cloudflare-Logpush-default-application`, `cx-Cloudflare-Logpush-default-subsystem`
+
 ## v1.0.12 / 2024-08-12
 ### 💡 Enhancements 💡
 - page_shield_events and sinkhole_http_logs Datasets added.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-## v1.0.14 / 2024-12-15
+## v1.1.0 / 2024-12-15
 ### 💡 Enhancements 💡
 - Add support for new region `AP3`, and for  regions syntax: `EU1`, `EU2`, `AP1`, `AP2`, `US1`
 - Replaced deprecated filed `frequency` with `max_upload_bytes`, `max_upload_interval_seconds` and  `max_upload_records` 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Changelog
 ## v1.0.14 / 2024-12-15
 ### 💡 Enhancements 💡
-- Add support for new rgion `AP3`, and for  regions syntax: `EU1`, `EU2`, `AP1`, `AP2`, `US1`
-- Replaced depricated filed `frequency` with `max_upload_bytes`, `max_upload_interval_seconds` and  `max_upload_records` 
-- Add default value for `coralogix_application_name` and `coralogix_subsystem_name`: `cx-Cloudflare-Logpush-default-application`, `cx-Cloudflare-Logpush-default-subsystem`
+- Add support for new region `AP3`, and for  regions syntax: `EU1`, `EU2`, `AP1`, `AP2`, `US1`
+- Replaced deprecated filed `frequency` with `max_upload_bytes`, `max_upload_interval_seconds` and  `max_upload_records` 
+- Add default value for `coralogix_application_name` and `coralogix_subsystem_name` variables: `cx-Cloudflare-Logpush-default-application`, `cx-Cloudflare-Logpush-default-subsystem`
 
 ## v1.0.12 / 2024-08-12
 ### 💡 Enhancements 💡

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,20 @@
+# Contributing Guide
+
+Welcome! We are glad that you want to contribute to our project! 💖
+
+If you'd like to report a bug or suggest a feature or get in touch with the repository owners for any other reason, the best way to do this is by opening an issue on the repository.
+
+In case of a bug report, please be precise in your description, and include all the relevant information, such as the integration that you are trying to deploy, the version of the integration that you are using ...
+
+If you'd like to contribute to our code or documentation, the best way to go about this is to first open an issue (if you have e.g. a new feature you'd like to contribute) and discuss with the repository owners, before submitting the change itself.
+
+## Pull Request Process
+
+We require all of our commits to be signed, please make sure they are signed by following [this guide](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
+
+## Requried changes
+When you submit a change you will need to make sure that you made all of the necessary changes:
+- Update the CHANGELOG.md file
+
+## release formate
+In order to release a new version the PR title and the commits needs to be in the following format : `release type: message`. Possible release types are: `fix` --> fixing a bug, `feat` --> adding a new feature, `major` --> apply major changes to a module for example breaking change.

--- a/modules/logpush-job/README.md
+++ b/modules/logpush-job/README.md
@@ -51,12 +51,17 @@ module "logpush-job" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_coralogix_region"></a> [coralogix\_region](#input\_coralogix\_region) | The Coralogix location region, possible options are [`Europe`, `Europe2`, `India`, `Singapore`, `US`, `US2`] | `string` | `Europe` | no |
+| <a name="input_coralogix_region"></a> [coralogix\_region](#input\_coralogix\_region) | The Coralogix location region, possible options are [`EU1`, `EU2`, `AP1`, `AP2`, `US1`, `US2`, `AP3`] | `string` | `EU1` | no |
 | <a name="input_coralogix_private_key"></a> [coralogix\_private\_key](#input\_coralogix\_private\_key) | The Coralogix private key which is used to validate your authenticity | `string` | n/a | yes |
+| <a name="input_coralogix_application_name"></a> [coralogix\_application\_name](#input\_coralogix\_application\_name) | The Coralogix Application Name for your logs | `string` | `cx-Cloudflare-Logpush-default-application` | no |
+| <a name="input_coralogix_subsystem_name"></a> [coralogix\_subsystem\_name](#input\_coralogix\_subsystem\_name) | The Coralogix SubSystem Name for your logs | `string` | `cx-Cloudflare-Logpush-default-subsystem` | no |
 | <a name="input_cloudflare_logpush_dataset"></a> [cloudflare\_logpush\_dataset](#input\_cloudflare\_logpush\_dataset) | The cloudflare logpush job data-set | `string` | n/a | yes |
 | <a name="input_cloudflare_logpush_fields"></a> [cloudflare\_logpush\_fields](#input\_cloudflare\_logpush\_fields) | The logpush dataset specific fields to log delimited with comma, leave empty to include all fields. the timestamp and its variants are included automatically. | `string` | "" | no |
 | <a name="input_cloudflare_zone_id"></a> [cloudflare\_zone\_id](#input\_cloudflare\_zone\_id) | The cloudflare zone id for zone based data-sets | `string` | "" | yes (for zone-scoped datasets) |
 | <a name="input_cloudflare_account_id"></a> [cloudflare\_account\_id](#input\_cloudflare\_account\_id) | The cloudflare account id for account based data-sets | `string` | "" | yes (for account-scoped datasets) |
+| <a name="input_max_upload_bytes"></a> [max\_upload\_bytes](#input\_max\_upload\_bytes) | The maximum uncompressed file size of a batch of logs. This setting value must be between 5 MB and 1 GB. This parameter is not available for jobs with `edge` as its kind | `number` | n/a | no |
+| <a name="input_max_upload_interval_seconds"></a> [max\_upload\_interval\_seconds](#input\_max\_upload\_interval\_seconds) | The maximum interval in seconds for log batches. This setting must be between 30 and 300 seconds (5 minutes). This parameter is not available for jobs with `edge` as its kind. | `number` | n/a | no |
+| <a name="input_max_upload_records"></a> [max\_upload\_records](#input\_max\_upload\_records) | The maximum number of log lines per batch. This setting must be between 1000 and 1,000,000 lines. This parameter is not available for jobs with `edge` as its kind | `number` | n/a | no |
 
 ## Outputs
 

--- a/modules/logpush-job/main.tf
+++ b/modules/logpush-job/main.tf
@@ -2,11 +2,17 @@ locals {
   job_name = "Coralogix-${replace(var.cloudflare_logpush_dataset,"_","-")}-${random_string.this.result}"
   coralogix_regions = {
     Europe    = "ingress.coralogix.com"
+    EU1       = "ingress.coralogix.com"
     Europe2   = "ingress.eu2.coralogix.com"
+    EU2       = "ingress.eu2.coralogix.com"
     India     = "ingress.app.coralogix.in"
+    AP1       = "ingress.app.coralogix.in"
     Singapore = "ingress.coralogixsg.com"
+    AP2       = "ingress.coralogixsg.com"
     US        = "ingress.coralogix.us"
+    US1       = "ingress.coralogix.us"
     US2       = "ingress.cx498.coralogix.com"
+    AP3       = "ingress.ap3.coralogix.com"
   }
   coralogix_dataset = {
     dns_logs = "DNSLogs"
@@ -110,7 +116,10 @@ resource "cloudflare_logpush_job" "crx-logpush-zone" {
   name                = local.job_name
   destination_conf = var.coralogix_subsystem_name != "" || var.coralogix_application_name != "" ? "https://${local.coralogix_regions[var.coralogix_region]}/cloudflare/v1/logs?header_Authorization=Bearer%20${var.coralogix_private_key}&header_CX-Application-Name=${var.coralogix_application_name}&header_CX-Subsystem-Name=${var.coralogix_subsystem_name}&header_timestamp-format=UnixNano&header_dataset=${local.coralogix_dataset[var.cloudflare_logpush_dataset]}&tags=dataset:${var.cloudflare_logpush_dataset}" : "https://${local.coralogix_regions[var.coralogix_region]}/cloudflare/v1/logs?header_Authorization=Bearer%20${var.coralogix_private_key}&header_timestamp-format=UnixNano&header_dataset=${local.coralogix_dataset[var.cloudflare_logpush_dataset]}&tags=dataset:${var.cloudflare_logpush_dataset}"
   dataset             = var.cloudflare_logpush_dataset
-  frequency = "low"
+  # frequency = "low"
+  max_upload_bytes = var.max_upload_bytes 
+  max_upload_interval_seconds = var.max_upload_interval_seconds
+  max_upload_records = var.max_upload_records 
   filter = var.cloudflare_zone_filter
   ownership_challenge = ""
   kind = ""
@@ -130,7 +139,10 @@ resource "cloudflare_logpush_job" "crx-logpush-account" {
   name                = local.job_name
   destination_conf = var.coralogix_subsystem_name != "" || var.coralogix_application_name != "" ? "https://${local.coralogix_regions[var.coralogix_region]}/cloudflare/v1/logs?header_Authorization=Bearer%20${var.coralogix_private_key}&header_CX-Application-Name=${var.coralogix_application_name}&header_CX-Subsystem-Name=${var.coralogix_subsystem_name}&header_timestamp-format=UnixNano&header_dataset=${local.coralogix_dataset[var.cloudflare_logpush_dataset]}&tags=dataset:${var.cloudflare_logpush_dataset}" : "https://${local.coralogix_regions[var.coralogix_region]}/api/v1/cloudflare/logs?header_Authorization=Bearer%20${var.coralogix_private_key}&header_timestamp-format=UnixNano&header_dataset=${local.coralogix_dataset[var.cloudflare_logpush_dataset]}&tags=dataset:${var.cloudflare_logpush_dataset}"
   dataset             = var.cloudflare_logpush_dataset
-  frequency = "low"
+  # frequency = "low"
+  max_upload_bytes = var.max_upload_bytes 
+  max_upload_interval_seconds = var.max_upload_interval_seconds
+  max_upload_records = var.max_upload_records 
   filter = var.cloudflare_account_filter
   ownership_challenge = ""
   kind = ""

--- a/modules/logpush-job/variables.tf
+++ b/modules/logpush-job/variables.tf
@@ -1,10 +1,10 @@
 variable "coralogix_region" {
-  description = "The Coralogix location region, possible options are [Europe, Europe2, India, Singapore, US, US2]"
+  description = "The Coralogix location region, possible options are [EU1, EU2, AP1, AP2, US1, US2, AP3]"
   type        = string
-  default     = "Europe"
+  default     = "EU1"
     validation {
-    condition = contains(["Europe","Europe2","India","Singapore","US","US2"], var.coralogix_region)
-    error_message = "The coralogix region must be on of these values: [Europe, Europe2, India, Singapore, US, US2]."
+    condition = contains(["Europe","Europe2","India","Singapore","US","US2","AP3","EU1","EU2","AP1","Ap2","US2"], var.coralogix_region)
+    error_message = "The coralogix region must be on of these values: [Europe, Europe2, India, Singapore, US, US2, AP3, EU1, EU2, AP1, AP2, US1]."
   }
 }
 
@@ -45,14 +45,14 @@ variable "coralogix_application_name" {
   description = "The Coralogix Application Name for your logs"
   type        = string
   sensitive   = true
-  default     = ""
+  default     = "cx-Cloudflare-Logpush-default-application"
 }
 
 variable "coralogix_subsystem_name" {
   description = "The Coralogix SubSystem Name for your logs"
   type        = string
   sensitive   = true
-  default     = ""
+  default     = "cx-Cloudflare-Logpush-default-subsystem"
 }
 
 variable "cloudflare_account_filter" {
@@ -77,4 +77,37 @@ variable "cloudflare_zone_sample_rate" {
   description = "The sample rate for zone based data-sets"
   type        = number
   default     = 1
+}
+
+variable "max_upload_bytes" {
+  description = "The maximum uncompressed file size of a batch of logs"
+  type        = number
+  default     = null
+
+  validation {
+    condition     = var.max_upload_bytes == null || (coalesce(var.max_upload_bytes, 0) >= 1 && coalesce(var.max_upload_bytes, 0) <= 5)
+    error_message = "This setting value must be between 5 MB and 1 GB"
+  }
+}
+
+variable "max_upload_interval_seconds" {
+  description = "The maximum interval in seconds for log batches"
+  type        = number
+  default     = null
+
+  validation {
+    condition     = var.max_upload_interval_seconds == null || (coalesce(var.max_upload_interval_seconds, 0) >= 30 && coalesce(var.max_upload_interval_seconds, 0) <= 300)
+    error_message = "This setting must be between 30 and 300 seconds (5 minutes)"
+  }
+}
+
+variable "max_upload_records" {
+  description = "The maximum number of log lines per batch"
+  type        = number
+  default     = null
+
+  validation {
+    condition     = var.max_upload_records == null || (coalesce(var.max_upload_records, 0) >= 100 && coalesce(var.max_upload_records, 0) <= 1000000)
+    error_message = "This setting must be between 1000 and 1,000,000 lines"
+  }
 }


### PR DESCRIPTION
- Add support for new region `AP3`, and for  regions syntax: `EU1`, `EU2`, `AP1`, `AP2`, `US1`
- Replaced deprecated filed `frequency` with `max_upload_bytes`, `max_upload_interval_seconds` and  `max_upload_records` 
- Add default value for `coralogix_application_name` and `coralogix_subsystem_name` variables: `cx-Cloudflare-Logpush-default-application`, `cx-Cloudflare-Logpush-default-subsystem`